### PR TITLE
Updated link to developer docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,7 @@ workflow definition file. For example, to run N2 on Agave we would update the ab
 
 
 To use either approach, you first need an Agave account and an API client. If you don't have those already you can
-get those here: http://preview.agaveapi.co/documentation/beginners-guides/
+get those here: http://developer.agaveapi.co/#guides
 
 Configuration
 -------------


### PR DESCRIPTION
The link to the Agave developer docs was out-dated. This pull request updates it.
